### PR TITLE
Moved registering additional service providers to register() method

### DIFF
--- a/src/EscolaLmsAuthServiceProvider.php
+++ b/src/EscolaLmsAuthServiceProvider.php
@@ -33,13 +33,13 @@ class EscolaLmsAuthServiceProvider extends ServiceProvider
     public function register()
     {
         $this->injectContract(self::CONTRACTS);
+        $this->app->register(EventServiceProvider::class);
+        $this->app->register(AuthServiceProvider::class);
     }
 
     public function boot()
     {
         $this->loadRoutesFrom(__DIR__ . '/routes.php');
         $this->loadMigrationsFrom(__DIR__ . '/../database/migrations');
-        $this->app->register(EventServiceProvider::class);
-        $this->app->register(AuthServiceProvider::class);
     }
 }


### PR DESCRIPTION
Moved registering additional service providers to EscolaLmsAuthServiceProvider register() method, instead of boot()

Should fix overriding event listeners in Templates package