### PR TITLE
Changed user settings response format

### DIFF
--- a/src/Http/Resources/UserSettingCollection.php
+++ b/src/Http/Resources/UserSettingCollection.php
@@ -19,7 +19,13 @@ class UserSettingCollection extends ResourceCollection
     {
         $this->withoutWrapping();
 
-        $fields = parent::toArray($request) + (config('user') ?? []);
+        $fields = [];
+        $parentFields = parent::toArray($request);
+        foreach ($parentFields as $setting) {
+            foreach ($setting as $key => $value) {
+                $fields[$key] = $value;
+            }
+        }
         return self::apply($fields, $this);
     }
 }

--- a/tests/API/ProfileApiTest.php
+++ b/tests/API/ProfileApiTest.php
@@ -116,10 +116,6 @@ class ProfileApiTest extends TestCase
             'key' => 'key2',
             'value' => 'value2',
         ]);
-        config(['user' => [
-            'default' => 'default',
-            'key3' => 'value3',
-        ]]);
 
         $this->response = $this->actingAs($user)->json('GET', '/api/profile/settings');
         $this->response

--- a/tests/API/ProfileApiTest.php
+++ b/tests/API/ProfileApiTest.php
@@ -121,9 +121,7 @@ class ProfileApiTest extends TestCase
         $this->response
             ->assertOk()
             ->assertJsonFragment(['test-key' => 'test-value'])
-            ->assertJsonFragment(['key2' => 'value2'])
-            ->assertJsonFragment(['default' => 'default'])
-            ->assertJsonFragment(['key3' => 'value3']);
+            ->assertJsonFragment(['key2' => 'value2']);
     }
 
     public function testSettingsUpdate(): void


### PR DESCRIPTION
- removed calls to `config('user')`, no idea what was their purpose, but I don't think we use them to anything anymore