### PR TITLE
Small hack for sending and returning return_url during google oauth flow

### DIFF
--- a/src/Http/Controllers/AuthApiController.php
+++ b/src/Http/Controllers/AuthApiController.php
@@ -106,7 +106,10 @@ class AuthApiController extends EscolaLmsBaseController implements AuthSwagger
             return null;
         }
         $json = json_decode($decoded, true);
-        return $json['return_url'] ?? null;
+        if (is_null($json) || !array_key_exists('return_url', $json)) {
+            return null;
+        }
+        return $json['return_url'];
     }
 
     public function verifyEmail(Request $request, string $id, string $hash): JsonResponse


### PR DESCRIPTION
Google ignores additional parameters sent in query to google oauth endpoint, so we need to use a little hack - sending base64 encoded data as `state` which is NOT ignored by Google and is sent back after successful login